### PR TITLE
Various Bug Fixes

### DIFF
--- a/DBVersioning/__init__.py
+++ b/DBVersioning/__init__.py
@@ -87,6 +87,11 @@ class VersionManager():
         self.deprication_warnings = deprication_warnings
         self.rollback_warnings = rollback_warnings
         self._states = {}
+        if versions is None: versions = []
+        try:
+            versions = list(versions)
+        except TypeError:
+            raise TypeError("Versions must be an iterable if supplied and should be a list or tuple")
         self.register_versions(*versions)
 
     def detach_interface(self):

--- a/DBVersioning/sqlite.py
+++ b/DBVersioning/sqlite.py
@@ -34,12 +34,13 @@ class SQLite3Interface(sqlite3.Connection, DBInterface):
         self.check_versiontable()
         
     def get_versiontable(self):
-        return self.execute("""SELECT * FROM __states;""").fetchall()
+        ## Make sure we use the original sqlite3.execute
+        return super().execute("""SELECT * FROM __states;""").fetchall()
 
     def check_versiontable(self):
         try: self.get_versiontable()
         except sqlite3.OperationalError:
-            self.execute("""CREATE TABLE __states (state TEXT UNIQUE, version TEXT);""")
+            super().execute("""CREATE TABLE __states (state TEXT UNIQUE, version TEXT);""")
             try:
                 self.get_versiontable()
             except:
@@ -56,12 +57,14 @@ class SQLite3Interface(sqlite3.Connection, DBInterface):
         """ Registers or Updates a State's Version in the __states table """
         state = stateversion.state.name
         version = str(stateversion.version)
-        self.execute("""INSERT INTO __states (state, version) VALUES (:state, :version) ON CONFLICT (state) DO UPDATE SET version=excluded.version;""", dict(state = state, version=version))
+        ## Make sure we use the original sqlite3.execute
+        super().execute("""INSERT INTO __states (state, version) VALUES (:state, :version) ON CONFLICT (state) DO UPDATE SET version=excluded.version;""", dict(state = state, version=version))
 
     def remove_version(self, state):
         """ Removes a State from the __states table: ensure the State is completely rolled back before calling this method. """
         state = state.name
-        self.execute("""DELETE FROM __states WHERE state = :state;""", dict(state = state))
+        ## Make sure we use the original sqlite3.execute
+        super().execute("""DELETE FROM __states WHERE state = :state;""", dict(state = state))
 
 class StateVersion(SV):
     @classmethod


### PR DESCRIPTION
Fixed a couple bugs/errors:

* **Fixed Subclassing issue** ([commit](https://github.com/AdamantLife/DBVersioning/commit/91a12cf4892f94dbf08efdf88fb7c76e6c56e080))

    Made sure to use super().execute within SQLite3Interface in order to allow subclasses to do whatever they like with the execute method. Included simple TestCase

* **VersionsManager versions argument** ([commit](https://github.com/AdamantLife/DBVersioning/commit/4576672b79d863887074238c788190584eafba8e))

    VersionManager was not doing any value checking for it's *versions* keyword argument. If no versions were passed or an non-iterable was passed it would raise an Exception on VersionManager.register_versions(*versions).

    Updated to change None/no argument to list() and a try/except to shallow copy versions, raising an error if it can't to properly explain that versions should be an iterable.