### PR TITLE
Force Commits of sqlite version changes

### DIFF
--- a/DBVersioning/sqlite.py
+++ b/DBVersioning/sqlite.py
@@ -59,12 +59,14 @@ class SQLite3Interface(sqlite3.Connection, DBInterface):
         version = str(stateversion.version)
         ## Make sure we use the original sqlite3.execute
         super().execute("""INSERT INTO __states (state, version) VALUES (:state, :version) ON CONFLICT (state) DO UPDATE SET version=excluded.version;""", dict(state = state, version=version))
+        self.commit()
 
     def remove_version(self, state):
         """ Removes a State from the __states table: ensure the State is completely rolled back before calling this method. """
         state = state.name
         ## Make sure we use the original sqlite3.execute
         super().execute("""DELETE FROM __states WHERE state = :state;""", dict(state = state))
+        self.commit()
 
 class StateVersion(SV):
     @classmethod


### PR DESCRIPTION
Sqlite3 doesn't commit changes until necessary, which may result in version changes being lost, which could in turn result in errors when the database version checked later. So set_version and remove_version both commit after changing the __states table